### PR TITLE
Fix naming of swift-snapshot-testing package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "SnapshotTesting",
+        "package": "swift-snapshot-testing",
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
         "state": {
           "branch": null,
-          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
-          "version": "1.9.0"
+          "revision": "f29e2014f6230cf7d5138fc899da51c7f513d467",
+          "version": "1.10.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     name: "SnapshotTestingHEIC",
     platforms: [
         .iOS(.v11),
-        .macOS(.v10_13),
+        .macOS(.v10_15),
         .tvOS(.v10)
     ],
     products: [
@@ -17,16 +17,16 @@ let package = Package(
             targets: ["SnapshotTestingHEIC"]),
     ],
     dependencies: [
-        .package(name: "SnapshotTesting",
+        .package(name: "swift-snapshot-testing",
                  url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
-                 from: "1.8.0"),
+                 from: "1.10.0"),
     ],
     targets: [
         .target(
             name: "SnapshotTestingHEIC",
             dependencies: [
                 .product(name: "SnapshotTesting",
-                         package: "SnapshotTesting"),
+                         package: "swift-snapshot-testing"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Fix issue caused by recent release of swift-snapshot-testing which changed its package name: https://github.com/pointfreeco/swift-snapshot-testing/releases/tag/1.10.0
