### PR TITLE
Fix minimum platform version to match swift-snapshot-testing package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,9 @@ import Foundation
 let package = Package(
     name: "SnapshotTestingHEIC",
     platforms: [
-        .iOS(.v11),
+        .iOS(.v13),
         .macOS(.v10_15),
-        .tvOS(.v10)
+        .tvOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
Sorry to miss this, not sure why my Xcode didn't report it. But swift-snapshot-testing also increases the minimum platform versions (see [here](https://github.com/pointfreeco/swift-snapshot-testing/blob/main/Package.swift)). I changed the Package.swift to match their requirements